### PR TITLE
Don't save the ducked radio volume as the default radio volume

### DIFF
--- a/Radio/src/com/example/radio/IntentActivity.java
+++ b/Radio/src/com/example/radio/IntentActivity.java
@@ -66,7 +66,7 @@ public class IntentActivity extends Activity implements ServiceConnection, Callb
 	}
 	
 	public void setVolume(int volume){
-		radioService.setVolume(volume);
+		radioService.setVolume(volume, true);
 	}
 
 	@Override

--- a/Radio/src/com/example/radio/RadioActivity.java
+++ b/Radio/src/com/example/radio/RadioActivity.java
@@ -1501,7 +1501,7 @@ public class RadioActivity extends Activity implements
 	@Override
 	public void onProgressChanged(SeekBar seekBar, int progress,
 			boolean fromUser) {
-		radioService.setVolume(progress);
+		radioService.setVolume(progress, true);
 	}
 
 	@Override

--- a/Radio/src/com/example/radio/RadioService.java
+++ b/Radio/src/com/example/radio/RadioService.java
@@ -231,7 +231,7 @@ public class RadioService extends Service implements RadioInterface,
 					e.printStackTrace();
 				}*/
 				setFreq(curFreq);
-				setVolume(mVolume);
+				setVolume(mVolume, true);
 				if(mRemote){
 					setRemote(1);
 				}else {
@@ -430,7 +430,7 @@ public class RadioService extends Service implements RadioInterface,
         switch (focusChange) {
             case AudioManager.AUDIOFOCUS_GAIN:
                 // Restore volume
-                setVolume(radioDuckVolume);
+                setVolume(radioDuckVolume, false);
                 break;
             case AudioManager.AUDIOFOCUS_LOSS:
                 stopService(new Intent("com.example.RadioService"));
@@ -439,12 +439,12 @@ public class RadioService extends Service implements RadioInterface,
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
                 // Reduce volume to Zero - save current volume;
                 radioDuckVolume = getVolume();
-                setVolume(0);
+                setVolume(0, false);
                 break;
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
                 // reduce volume by 50%
                 radioDuckVolume = getVolume();
-                setVolume(getVolume() / 2);
+                setVolume(getVolume() / 2, false);
                 break;
         }
 
@@ -489,13 +489,15 @@ public class RadioService extends Service implements RadioInterface,
 		radioType = type;
 	}
 
-	public int setVolume(int volume) {
+	public int setVolume(int volume, boolean savePref) {
 		mVolume = volume;
 		if (DEBUG) Log.v(TAG, "(Service)mVolume = "+mVolume);
 		jniSetVolume(mVolume);
-		SharedPreferences.Editor editor = settings.edit(); /* ��editor���ڱ���״̬ */
-		editor.putInt("mvolume", mVolume);
-		editor.commit();
+		if (savePref == true) {
+			SharedPreferences.Editor editor = settings.edit(); /* ��editor���ڱ���״̬ */
+			editor.putInt("mvolume", mVolume);
+			editor.commit();
+		}
 		return mVolume;
 	}
 

--- a/Radio/src/com/example/radio/RadioSetting.java
+++ b/Radio/src/com/example/radio/RadioSetting.java
@@ -104,7 +104,7 @@ public class RadioSetting extends Activity implements OnClickListener ,ServiceCo
 		@Override
 		public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
 			// TODO Auto-generated method stub
-			mSerivce2.setVolume(progress);
+			mSerivce2.setVolume(progress, true);
 		}
 
 		@Override


### PR DESCRIPTION
Only update the preference value when the volume slider is changed, ducking should never be saved as the default value.
