### PR TITLE
Create a concept of capabilities and presets

### DIFF
--- a/Bonovo_McuUpdate_And_Setting/res/layout/capabilities.xml
+++ b/Bonovo_McuUpdate_And_Setting/res/layout/capabilities.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical"
+              android:paddingBottom="10dp"
+              android:paddingLeft="10dp"
+              android:paddingRight="10dp"
+              android:paddingTop="25dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/choose_capabilities"
+        android:textColor="#00ced1"
+        android:textSize="20sp"/>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        android:layout_marginTop="7dp"
+        android:background="?android:attr/listDivider"/>
+
+    <!-- Presets selector -->
+
+    <LinearLayout android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:orientation="horizontal">
+        <TextView android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:text="@string/capability_preset"/>
+        <Spinner
+            android:id="@+id/spinner_presets"
+            android:layout_width="0px"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"/>
+    </LinearLayout>
+
+    <!-- List of checkable capabilities -->
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/all_capabilities"
+        android:textColor="#00ced1"
+        android:textSize="18sp"/>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        android:layout_marginTop="7dp"
+        android:background="?android:attr/listDivider"/>
+
+    <ListView
+        android:id="@android:id/list"
+        android:layout_width="match_parent"
+        android:layout_height="0px"
+        android:layout_weight="1"/>
+
+</LinearLayout>

--- a/Bonovo_McuUpdate_And_Setting/res/values/strings.xml
+++ b/Bonovo_McuUpdate_And_Setting/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="update_ok_msg">MCU update completed, rebooting unit</string>
     <string name="msg_1"> </string>
     <string name="list_version">Box Version</string>
+    <string name="list_capabilities">Capabilities</string>
     <string name="list_update">MCU Update</string>
     <string name="list_config">Car Config</string>
     <string name="list_serial_config">Serial Config</string>
@@ -67,4 +68,13 @@
     <string name="connectedstandby_half_day">After Twelve Hours</string>
     <string name="connectedstandby_one_day">After One Day</string>
     <string name="connectedstandby_infinite">Never</string>
+    <!-- Capabilities -->
+    <string name="choose_capabilities">Choose Capabilities</string>
+    <string name="capability_preset">Preset:</string>
+    <string name="preset_nu_series">NU Series (Carpad II)</string>
+    <string name="preset_nr_series">NR Series (Carpad III)</string>
+    <string name="preset_custom">Custom (Advanced)</string>
+    <string name="all_capabilities">All Capabilities</string>
+    <string name="cap_backlight_keys_custom_color">Edit keys backlight color</string>
+    <string name="cap_backlight_keys_brightness">Edit keys backlight brightness</string>
 </resources>

--- a/Bonovo_McuUpdate_And_Setting/src/com/bonovo/mcuupdate_and_setting/Capabilities.java
+++ b/Bonovo_McuUpdate_And_Setting/src/com/bonovo/mcuupdate_and_setting/Capabilities.java
@@ -1,0 +1,279 @@
+package com.bonovo.mcuupdate_and_setting;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+public class Capabilities {
+    /**
+     * Preset definition of capabilities for the NU series (Carpad II)
+     */
+    public static final CapabilitySet PRESET_NU_SERIES = new CapabilitySet(R.string.preset_nu_series,
+            Arrays.asList(Capability.BACKLIGHT_KEYS_CUSTOM_COLOR),
+            Arrays.asList(Capability.BACKLIGHT_KEYS_BRIGHTNESS));
+
+    /**
+     * Preset definition of capabilities for the NR series (Carpad III)
+     */
+    public static final CapabilitySet PRESET_NR_SERIES = new CapabilitySet(R.string.preset_nr_series,
+            Arrays.asList(Capability.BACKLIGHT_KEYS_BRIGHTNESS),
+            Arrays.asList(Capability.BACKLIGHT_KEYS_CUSTOM_COLOR));
+
+    private static final String TAG = "Capabilities";
+    private static final String PREFS_CUSTOM_CAPABILITIES = "com.bonovo.capabilities.custom";
+    private static final String PREFS_CAPABILITIES = "com.bonovo.capabilities";
+    private static final String PREFS_KEY_SELECTED = "selected";
+
+    private static final String PREF_SELECTED_NU = "PRESET_NU_SERIES";
+    private static final String PREF_SELECTED_NR = "PRESET_NR_SERIES";
+    private static final String PREF_SELECTED_CUSTOM = "PRESET_CUSTOM";
+    private static final String PREF_SELECTED_DEFAULT = PREF_SELECTED_NU;
+
+    public static CapabilitySet getSelected(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_CAPABILITIES, Context.MODE_PRIVATE);
+        String selected = prefs.getString(PREFS_KEY_SELECTED, PREF_SELECTED_DEFAULT);
+        CapabilitySet set = getSelected(context, selected);
+
+        if (set == null && !PREF_SELECTED_DEFAULT.equals(selected)) {
+            Log.w(TAG, "Unexpected preset selection '" + selected + "', falling back to default: " + PREF_SELECTED_DEFAULT);
+            // The previous selection may have been removed -- reset back to default
+            set = getSelected(context, PREF_SELECTED_DEFAULT);
+        }
+
+        return set;
+    }
+
+    public static void setSelected(Context context, CapabilitySet capabilitySet) {
+        if (capabilitySet == null) return;
+
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_CAPABILITIES, Context.MODE_PRIVATE);
+
+        if (capabilitySet.isEditable()) {
+            prefs.edit().putString(PREFS_KEY_SELECTED, PREF_SELECTED_CUSTOM).apply();
+        } else if (capabilitySet == PRESET_NU_SERIES) {
+            prefs.edit().putString(PREFS_KEY_SELECTED, PREF_SELECTED_NU).apply();
+        } else if (capabilitySet == PRESET_NR_SERIES) {
+            prefs.edit().putString(PREFS_KEY_SELECTED, PREF_SELECTED_NR).apply();
+        }
+    }
+
+    private static CapabilitySet getSelected(Context context, String selected) {
+        if (PREF_SELECTED_NU.equals(selected)) {
+            return PRESET_NU_SERIES;
+        } else if (PREF_SELECTED_NR.equals(selected)) {
+            return PRESET_NR_SERIES;
+        } else if (PREF_SELECTED_CUSTOM.equals(selected)) {
+            return getCustom(context);
+        }
+
+        return null;
+    }
+
+    /**
+     * Set of available capabilities
+     */
+    public enum Capability {
+        /**
+         * Allows setting a custom color for the backlit keys
+         */
+        BACKLIGHT_KEYS_CUSTOM_COLOR(R.string.cap_backlight_keys_custom_color),
+
+        /**
+         * Allows setting the brightness of the backlit keys
+         */
+        BACKLIGHT_KEYS_BRIGHTNESS(R.string.cap_backlight_keys_brightness),
+        /* End */;
+
+        public final int title;
+
+        Capability(int title) {
+            this.title = title;
+        }
+
+        /**
+         * @return The title string for this Capability, or {@code null} if no title has been defined
+         */
+        public String getTitle(Context context) {
+            return title == 0 ? null : context.getString(title);
+        }
+    }
+
+    /**
+     * Returns the user-customized set of capabilities.
+     */
+    static CapabilitySet getCustom(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_CUSTOM_CAPABILITIES, Context.MODE_PRIVATE);
+        Collection<Capability> enabled = new ArrayList<Capability>();
+        Collection<Capability> disabled = new ArrayList<Capability>();
+
+        for (Map.Entry<String, ?> e : prefs.getAll().entrySet()) {
+            if (e.getValue() instanceof Boolean) {
+                try {
+                    Capability cap = Capability.valueOf(e.getKey());
+
+                    if (Boolean.TRUE.equals(e.getValue())) {
+                        enabled.add(cap);
+                    } else if (Boolean.FALSE.equals(e.getValue())) {
+                        disabled.add(cap);
+                    }
+                } catch (IllegalArgumentException iae) {
+                    Log.w(TAG, "Discarding unknown capability entry: " + e);
+                }
+            }
+        }
+
+        return new CapabilitySet(R.string.preset_custom, enabled, disabled, prefs);
+    }
+
+    /**
+     * This represents a defined set of capabilities.
+     * <p>
+     * The pre-defined capability sets are unmodifiable, assigned by evaluating what each model is capable of.
+     * <p>
+     * It is also possible to create a customized set of capabilities, where the customizations are stored in shared preferences.
+     */
+    static class CapabilitySet {
+        private final int mTitle;
+
+        private final Collection<Capability> mEnabledCaps;
+        private final Collection<Capability> mDisabledCaps;
+
+        private SharedPreferences mPreferences;
+
+        private final SharedPreferences.OnSharedPreferenceChangeListener mPrefsListener = new SharedPreferences.OnSharedPreferenceChangeListener() {
+            @Override
+            public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+                if (mPreferences != null) {
+                    Capability cap;
+
+                    try {
+                        cap = Capability.valueOf(key);
+                    } catch (IllegalArgumentException iae) {
+                        return;
+                    }
+
+                    set(cap, sharedPreferences.getBoolean(key, mEnabledCaps.contains(cap)));
+                }
+            }
+        };
+
+        /**
+         * Creates a {@code CapabilitySet} with hard-coded capabilities. This object cannot be modified.
+         */
+        CapabilitySet(int title, Collection<Capability> enabled, Collection<Capability> disabled) {
+            this(title, enabled, disabled, null);
+        }
+
+        /**
+         * Creates a {@code CapabilitySet} with a {@link SharedPreferences}-backed storage component. These capabilities can be modified.
+         *
+         * @param title    String resource id to identify this {@code CapabilitySet}
+         * @param enabled  The set of enabled {@link Capability capabilities}
+         * @param disabled The set of disabled {@link Capability capabilities}
+         * @param prefs    Optional SharedPreferences storage backing
+         */
+        CapabilitySet(int title, Collection<Capability> enabled, Collection<Capability> disabled, SharedPreferences prefs) {
+            mTitle = title;
+            mEnabledCaps = enabled;
+            mDisabledCaps = disabled;
+            mPreferences = prefs;
+
+            if (prefs != null) {
+                prefs.registerOnSharedPreferenceChangeListener(mPrefsListener);
+            }
+        }
+
+        /**
+         * @param cap The Capability to test
+         * @return {@code true} if this {@code CapabilitySet} has enabled the given {@link Capability}; {@code false} otherwise
+         */
+        public boolean hasCapability(Capability cap) {
+            return mEnabledCaps.contains(cap) && !mDisabledCaps.contains(cap);
+        }
+
+        /**
+         * @param cap The Capability to test
+         * @return {@code true} if this {@code CapabilitySet} has defined whether the {@code cap} Capability is enabled or disabled.
+         */
+        public boolean isDefined(Capability cap) {
+            return mEnabledCaps.contains(cap) || mDisabledCaps.contains(cap);
+        }
+
+        /**
+         * Attempts to set the Capability preference
+         *
+         * @param cap     The Capability to modify
+         * @param enabled Whether the Capability should be enabled or not
+         * @return {@code true} if a change was made; {@code false} if nothing was changed.
+         * @throws UnsupportedOperationException if this CapabilitySet is incapable of being modified
+         */
+        public boolean set(Capability cap, boolean enabled) {
+            boolean didChange;
+
+            if (enabled) {
+                didChange = enable(cap);
+            } else {
+                didChange = disable(cap);
+            }
+
+            if (didChange && mPreferences != null) {
+                mPreferences.edit()
+                        .putBoolean(cap.name(), enabled)
+                        .apply();
+            }
+
+            return didChange;
+        }
+
+        /**
+         * Disables the {@code cap} Capability
+         *
+         * @param cap The Capability to modify
+         * @return {@code true} if a change was made; {@code false} if nothing was changed.
+         * @see #set(Capability, boolean)
+         */
+        public boolean disable(Capability cap) {
+            checkEditable();
+            return mEnabledCaps.remove(cap) | mDisabledCaps.add(cap);
+        }
+
+
+        /**
+         * Enables the {@code cap} Capability
+         *
+         * @param cap The Capability to modify
+         * @return {@code true} if a change was made; {@code false} if nothing was changed.
+         * @see #set(Capability, boolean)
+         */
+        public boolean enable(Capability cap) {
+            checkEditable();
+            return mDisabledCaps.remove(cap) | mEnabledCaps.add(cap);
+        }
+
+        /**
+         * @return The title string for this CapabilitySet, or {@code null} if no title has been defined
+         */
+        public String getTitle(Context context) {
+            return mTitle == 0 ? null : context.getString(mTitle);
+        }
+
+        /**
+         * @return {@code true} if this CapabilitySet can be modified.
+         * <p>
+         * If this returns {@code false}, any calls to {@link #set(Capability, boolean)},
+         * {@link #enable(Capability)}, or {@link #disable(Capability)} will throw {@link UnsupportedOperationException}.
+         */
+        public boolean isEditable() {
+            return mPreferences != null;
+        }
+
+        private void checkEditable() {
+            if (!isEditable()) throw new UnsupportedOperationException("This capability set is not editable");
+        }
+    }
+}

--- a/Bonovo_McuUpdate_And_Setting/src/com/bonovo/mcuupdate_and_setting/LeftFragment.java
+++ b/Bonovo_McuUpdate_And_Setting/src/com/bonovo/mcuupdate_and_setting/LeftFragment.java
@@ -1,10 +1,5 @@
 package com.bonovo.mcuupdate_and_setting;
 
-import java.util.ArrayList;
-import java.util.List;
-
-
-
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.app.ListFragment;
@@ -16,35 +11,54 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class LeftFragment extends ListFragment {
-	
+
 	private ArrayAdapter<String> adArrayAdapter;
 	private FragmentManager fragmentManager;
 	private FragmentTransaction transaction;
+
+	private static final int POS_VERSION = 0;
+	private static final int POS_CAPABILITIES = 1;
+	private static final int POS_MCU_UPDATE = 2;
+	private static final int POS_CAR_CONFIG = 3;
+	private static final int POS_SERIAL_CONFIG = 4;
+	private static final int POS_CAR_TYPE = 5;
+	private static final int POS_KEYS_BACKLIGHT = 6;
+	private static final int POS_OTG = 7;
+	private static final int POS_BT_UPDATE = 8;
+	private static final int POS_STANDBY = 9;
+
+	@SuppressWarnings("unused")
+	private static final int POS_UNUSED_SCROLLVIEW = 11;
+
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		// TODO Auto-generated method stub
 		super.onCreate(savedInstanceState);
-		adArrayAdapter = new ArrayAdapter<String>(getActivity(), android.R.layout.simple_list_item_1,getData());
+		adArrayAdapter = new ArrayAdapter<String>(getActivity(), android.R.layout.simple_list_item_1, getData());
 		fragmentManager = getFragmentManager();
 	}
-	
+
 	public List<String> getData(){
 		List<String> list = new ArrayList<String>();
-		list.add(getResources().getString(R.string.list_version));
-		list.add(getResources().getString(R.string.list_update));
-		list.add(getResources().getString(R.string.list_config));
-		//list.add("滚动框架");
-		list.add(getResources().getString(R.string.list_serial_config));
-		list.add(getResources().getString(R.string.list_car_config));
-		list.add(getResources().getString(R.string.list_keysbacklight));
-		list.add(getResources().getString(R.string.list_otg));
-		list.add(getResources().getString(R.string.list_btupdate));
-		list.add(getResources().getString(R.string.list_standby));
+		list.add(POS_VERSION, getResources().getString(R.string.list_version));
+		list.add(POS_CAPABILITIES, getResources().getString(R.string.list_capabilities));
+		list.add(POS_MCU_UPDATE, getResources().getString(R.string.list_update));
+		list.add(POS_CAR_CONFIG, getResources().getString(R.string.list_config));
+		list.add(POS_SERIAL_CONFIG, getResources().getString(R.string.list_serial_config));
+		list.add(POS_CAR_TYPE, getResources().getString(R.string.list_car_config));
+		list.add(POS_KEYS_BACKLIGHT, getResources().getString(R.string.list_keysbacklight));
+		list.add(POS_OTG, getResources().getString(R.string.list_otg));
+		list.add(POS_BT_UPDATE, getResources().getString(R.string.list_btupdate));
+		list.add(POS_STANDBY, getResources().getString(R.string.list_standby));
+		// list.add(POS_UNUSED_SCROLLVIEW, getResources().getString(R.string.list_scrollview));
+		//list.add("滚动框架"); // scroll framework
 		return list;
-		
 	}
-	
+
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container,
 			Bundle savedInstanceState) {
@@ -61,72 +75,55 @@ public class LeftFragment extends ListFragment {
 		super.onListItemClick(l, v, position, id);
 		Log.v("leftfragment","position is "+position);
 		transaction = fragmentManager.beginTransaction();
-		
+
 		switch (position) {
-		case 0:
+		case POS_VERSION:
 			RigthFragmentVersion rigthFragmentVersion = new RigthFragmentVersion();
 			transaction.replace(R.id.rigth, rigthFragmentVersion,"rigthFragmentVersion");
 			//transaction.addToBackStack(null);		//把事务添加到一个后退栈中,同时在后退栈中保存被代替的fragment的状态
 			break;
-		case 1:
+		case POS_CAPABILITIES:
+			RightFragmentCapabilities capsFragment = new RightFragmentCapabilities();
+			transaction.replace(R.id.rigth, capsFragment, "rightCapabilities");
+			break;
+		case POS_MCU_UPDATE:
 			McuFragment mcuFragment = new McuFragment();
 			transaction.replace(R.id.rigth, mcuFragment, "mchFragment");
 			//transaction.addToBackStack(null);
 			break;
-		case 2:
+		case POS_CAR_CONFIG:
 			RightFragmentSetting rightFragmentSetting = new RightFragmentSetting();
 			transaction.replace(R.id.rigth, rightFragmentSetting, "rightFragmentSetting");
 			//transaction.addToBackStack(null);
 			break;
-		case 3:
+		case POS_SERIAL_CONFIG:
 			RightFragmentSerialConfig rightFragmentSerialConfig = new RightFragmentSerialConfig();
 			transaction.replace(R.id.rigth, rightFragmentSerialConfig,"rightFragmentSerialConfig");
 			break;
-		case 4:
+		case POS_CAR_TYPE:
 			RightFragmentCarConfig rightFragmentCarConfig = new RightFragmentCarConfig();
 			transaction.replace(R.id.rigth, rightFragmentCarConfig, "rightFragmentCarConfig");
 			break;
-		case 5:
+		case POS_KEYS_BACKLIGHT:
 			RightFragmentKeysBackLight rightFragmentKeysBackLight = new RightFragmentKeysBackLight();
 			transaction.replace(R.id.rigth, rightFragmentKeysBackLight, "rightFragmentCarConfig");
 			break;
-		case 6:
+		case POS_OTG:
 			RightFragmentOTGModel rightFragmentOTGModel = new RightFragmentOTGModel();
 			transaction.replace(R.id.rigth, rightFragmentOTGModel, "rightFragmentOTGModel");
 			break;
-		case 7:
+		case POS_BT_UPDATE:
 			BTUpdateFragment fragmentBTUpdate = new BTUpdateFragment();
 			transaction.replace(R.id.rigth, fragmentBTUpdate, "fragmentBTUpdate");
 			break;
-		case 8:
+		case POS_STANDBY:
 			RightFragmentStandby fragmentStandby = new RightFragmentStandby();
 			transaction.replace(R.id.rigth, fragmentStandby, "fragmentStandby");
 			break;
-		case 10:
-			RightFragmentScrollView fragmentScrollView = new RightFragmentScrollView();
-			transaction.replace(R.id.rigth, fragmentScrollView, "fragmentScrollView");
-			//transaction.addToBackStack(null);
-			break;
 		default:
-			break;
+            Log.w("leftfragment", "Unexpected item click: " + position);
+            return;
 		}
-//		String itemString = adArrayAdapter.getItem(position);
-//		//����ߵ�Fragment �е�� �滻�ұߵ�Fragment
-//		RigthFragment rigthFragment = new RigthFragment();
-//		transaction = fragmentManager.beginTransaction();
-//		transaction.replace(R.id.rigth, rigthFragment,"rigthFragment");
-////		transaction.addToBackStack("rigthFragment");
-//		Bundle bundle = new Bundle();
-//		bundle.putString("item", itemString);
-//		rigthFragment.setArguments(bundle);
 		transaction.commit();
-		
 	}
-	
-	@Override
-	public void onPause() {
-		// TODO Auto-generated method stub
-		super.onPause();
-	}
-
 }

--- a/Bonovo_McuUpdate_And_Setting/src/com/bonovo/mcuupdate_and_setting/RightFragmentCapabilities.java
+++ b/Bonovo_McuUpdate_And_Setting/src/com/bonovo/mcuupdate_and_setting/RightFragmentCapabilities.java
@@ -1,0 +1,167 @@
+package com.bonovo.mcuupdate_and_setting;
+
+import android.app.ListFragment;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.BaseAdapter;
+import android.widget.CheckedTextView;
+import android.widget.ListView;
+import android.widget.Spinner;
+import android.widget.TextView;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RightFragmentCapabilities extends ListFragment {
+    private Capabilities.CapabilitySet mSelected;
+
+    private Spinner mSpinner;
+    private CapabilitiesAdapter mCapsAdapter;
+    private PresetsAdapter mPresetsAdapter;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mSelected = Capabilities.getSelected(getActivity());
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.capabilities, container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        mSpinner = (Spinner) view.findViewById(R.id.spinner_presets);
+        List<Capabilities.CapabilitySet> presets = Arrays.asList(Capabilities.PRESET_NU_SERIES,
+                Capabilities.PRESET_NR_SERIES,
+                Capabilities.getCustom(getActivity()));
+
+        mPresetsAdapter = new PresetsAdapter(getActivity(), presets);
+        mSpinner.setAdapter(mPresetsAdapter);
+
+        // Pre-select the saved item (the "Custom" item is dynamically created, so can't use indexOf())
+        mSpinner.setSelection(mSelected.isEditable() ? presets.size() - 1
+                : presets.indexOf(mSelected));
+
+        // When the selection changes, we have to update the individual capabilities in the list
+        mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                mSelected = mPresetsAdapter.getItem(position);
+                mCapsAdapter = new CapabilitiesAdapter(getActivity(), mSelected);
+                setListAdapter(mCapsAdapter);
+                mCapsAdapter.notifyDataSetChanged();
+                Capabilities.setSelected(getActivity(), mSelected);
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+            }
+        });
+
+        mCapsAdapter = new CapabilitiesAdapter(getActivity(), mSelected);
+        setListAdapter(mCapsAdapter);
+    }
+
+    @Override
+    public void onListItemClick(ListView l, View v, int position, long id) {
+        if (v.isEnabled() && mSelected != null && mSelected.isEditable()) {
+            Capabilities.Capability cap = (Capabilities.Capability) l.getItemAtPosition(position);
+            mSelected.set(cap, !mSelected.hasCapability(cap));
+
+            l.setItemChecked(position, mSelected.hasCapability(cap));
+            mCapsAdapter.notifyDataSetChanged();
+        }
+    }
+
+    private static class PresetsAdapter extends BaseAdapter {
+        private final LayoutInflater mInflater;
+        private final Context mContext;
+        private final List<Capabilities.CapabilitySet> mPresets;
+
+        PresetsAdapter(Context context, List<Capabilities.CapabilitySet> presets) {
+            mContext = context;
+            mInflater = LayoutInflater.from(context);
+            mPresets = presets;
+        }
+
+        @Override
+        public int getCount() {
+            return mPresets.size();
+        }
+
+        @Override
+        public Capabilities.CapabilitySet getItem(int position) {
+            return mPresets.get(position);
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            TextView view = (TextView) convertView;
+
+            if (view == null) {
+                view = (TextView) mInflater.inflate(android.R.layout.simple_spinner_item, parent, false);
+            }
+
+            Capabilities.CapabilitySet item = getItem(position);
+            view.setText(item.getTitle(mContext));
+            return view;
+        }
+    }
+
+    private static class CapabilitiesAdapter extends BaseAdapter {
+        private final Context mContext;
+        private final LayoutInflater mInflater;
+        private final Capabilities.CapabilitySet mCaps;
+
+        private static final Capabilities.Capability[] sValues = Capabilities.Capability.values();
+
+        CapabilitiesAdapter(Context context, Capabilities.CapabilitySet selected) {
+            mInflater = LayoutInflater.from(context);
+            mContext = context;
+            mCaps = selected;
+        }
+
+        @Override
+        public int getCount() {
+            return sValues.length;
+        }
+
+        @Override
+        public Capabilities.Capability getItem(int position) {
+            return sValues[position];
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            CheckedTextView view = (CheckedTextView) convertView;
+
+            if (view == null) {
+                view = (CheckedTextView) mInflater.inflate(android.R.layout.simple_list_item_checked, parent, false);
+                view.setEnabled(mCaps.isEditable());
+            }
+
+            Capabilities.Capability item = getItem(position);
+            view.setText(item.getTitle(mContext));
+            view.setChecked(mCaps.hasCapability(item));
+            return view;
+        }
+    }
+}


### PR DESCRIPTION
This allows individual features (Capability) of the devices to be toggleable,
and a set of pre-defined presets with capabilities enabled/disabled. Those
presets coincide with the NU- and NR-series of devices.

The user is able to choose which preset they want to enable, or optionally
take full control over the capabilities to enable/disable specific features
that he wants.

Eventually this concept should probably move into the com.bonovo framework,
so that other apps and system services can make use of the presets and
capabilities.

For now, nothing is actually using the capabilities, but coming soon, we
should update the MCU Settings to enable/disable certain features in the UI
based on the capability selections.

Issue: Nu3001/xdAuto#8
