### PR TITLE
Allow building BonovoMcu manually if needed

### DIFF
--- a/BonovoMcu/Android.mk.disabled
+++ b/BonovoMcu/Android.mk.disabled
@@ -1,0 +1,20 @@
+LOCAL_PATH:= $(call my-dir)
+include $(CLEAR_VARS)
+
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_SRC_FILES := $(call all-java-files-under, src)
+
+LOCAL_PACKAGE_NAME := BonovoMcuOld
+
+#LOCAL_OVERRIDES_PACKAGES := bonovomcu
+
+# deleted by shmin for using android.os.SystemProperties class
+#LOCAL_SDK_VERSION := current:
+
+LOCAL_PROGUARD_ENABLED := disabled
+
+include $(BUILD_PACKAGE)
+
+# Use the following include to make our test apk.
+include $(call all-makefiles-under,$(LOCAL_PATH))


### PR DESCRIPTION
All this does is add back the Android.mk file as `Android.mk.disabled`.  The disabled extension allows it to be ignored as intended, but makes it easier to rename the file to `Android.mk` if you want to build it.
