### PR TITLE
Radio "scan" mode

### DIFF
--- a/Radio/res/values-en-rUS/strings.xml
+++ b/Radio/res/values-en-rUS/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="fine">Tune</string>
+    <string name="step">Seek</string>
+
+    <string name="samefreq">This frequency is already saved</string>
+    <string name="no_reminds">Don\'t show again</string>
+</resources>

--- a/Radio/res/values/arrays.xml
+++ b/Radio/res/values/arrays.xml
@@ -8,7 +8,7 @@
             <item>@string/ITURegion2</item>
             <item>@string/ITURegion3</item>
     </string-array>
-    
+
     <string-array name="department_value">
         <item>1</item>
         <item>2</item>
@@ -28,6 +28,24 @@
         <item>1</item>
         <item>2</item>
         <item>3</item>
+    </string-array>
+
+    <string-array name="scan_delays">
+        <item>@string/scan_delay_1</item>
+        <item>@string/scan_delay_2</item>
+        <item>@string/scan_delay_3</item>
+        <item>@string/scan_delay_5</item>
+        <item>@string/scan_delay_7</item>
+        <item>@string/scan_delay_10</item>
+    </string-array>
+
+    <string-array name="scan_delay_values" translatable="false">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>5</item>
+        <item>7</item>
+        <item>10</item>
     </string-array>
 
 </resources>

--- a/Radio/res/values/strings.xml
+++ b/Radio/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="fine">Fine</string>
     <string name="step">Step</string>
     <string name="auto">Auto</string>
+    <string name="start_scan">Scanning from %s&#8230;</string>
+    <string name="scanning">Scanning&#8230;</string>
     <string name="radio_volume">Radio-Volume</string>
     <string name="fmsearch">Start searching the FM band frequency?</string>
     <string name="amsearch">Start searching the AM band frequency?</string>
@@ -30,7 +32,7 @@
     <string name="alert_dialog_cancel">Cancel</string>
     <string name="valid_freq_fm">Please Enter Valid FM Freq：87.5-108.0MHz</string>
     <string name="valid_freq_am">Please Enter Valid AM Freq：520-1710KHz</string>
-    <string name="searchwait">Searching Now, Please Wait For A While...</string>
+    <string name="searchwait">Searching Now, Please Wait...</string>
     <string name="china">China</string>
     <string name="japan">Japan</string>
     <string name="europe">Europe</string>
@@ -68,7 +70,7 @@
     <string name="no_reminds">Next time no longer prompt</string>
     <string name="addHeart">addHeart</string>
     <string name="is_addHeart_toast">Has been added to the collection</string>
-    <string name="same_addHeart_toast">Collection already has this freq</string>
+    <string name="same_addHeart_toast">Collection already has this frequency</string>
     <string name="clear_single_channel">Clear the currently selected channel info?</string>
     <string name="clear_addHeart_toast">Frequency has been dropped from the collection</string>
     <string name="not_effective_freq">Not effective frequency</string>

--- a/Radio/res/values/strings.xml
+++ b/Radio/res/values/strings.xml
@@ -85,4 +85,13 @@
     <string name="layout_choose_title">Please select a Design</string>
     <string name="widget_loading">Loading...</string>
 
+    <string name="scan">Scan</string>
+    <string name="pref_scan_delay">Scan delay</string>
+    <string name="scan_delay_1">1 second</string>
+    <string name="scan_delay_2">2 seconds</string>
+    <string name="scan_delay_3">3 seconds</string>
+    <string name="scan_delay_5">5 seconds</string>
+    <string name="scan_delay_7">7 seconds</string>
+    <string name="scan_delay_10">10 seconds</string>
+
 </resources>

--- a/Radio/res/xml/preference_setting.xml
+++ b/Radio/res/xml/preference_setting.xml
@@ -60,4 +60,17 @@
 
     </PreferenceCategory>
 
+
+    <PreferenceCategory android:title="@string/scan">
+
+        <ListPreference
+            android:dialogTitle="@string/pref_scan_delay"
+            android:entries="@array/scan_delays"
+            android:entryValues="@array/scan_delay_values"
+            android:key="scan_delay_list_preference"
+            android:title="@string/pref_scan_delay"
+            android:defaultValue="3" />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/Radio/src/com/example/radio/MyPreferenceFragment.java
+++ b/Radio/src/com/example/radio/MyPreferenceFragment.java
@@ -13,6 +13,7 @@ import android.preference.PreferenceScreen;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceFragment;
+import android.text.format.DateUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -21,11 +22,12 @@ public class MyPreferenceFragment extends PreferenceFragment implements
 		OnPreferenceClickListener, OnPreferenceChangeListener {
 	private Activity context;
 	private CallbackSetting callbackSetting;
-	
+
 	private VolumeSeekBarPreferences seekBarPreferences;
 	private CheckBoxPreference checkBoxRemote;
 	private ListPreference countryListPre;
 	private ListPreference layoutList;
+	private ListPreference scanDelayPref;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -51,7 +53,7 @@ public class MyPreferenceFragment extends PreferenceFragment implements
 		checkBoxRemote = (CheckBoxPreference) findPreference("checkbox_remote_preference");
 		checkBoxRemote.setOnPreferenceChangeListener(this);
 		checkBoxRemote.setOnPreferenceClickListener(this);
-		
+
 		countryListPre = (ListPreference) findPreference("countries_list_preference");
 		countryListPre.setOnPreferenceChangeListener(this);
 		countryListPre.setOnPreferenceClickListener(this);
@@ -60,6 +62,8 @@ public class MyPreferenceFragment extends PreferenceFragment implements
 		layoutList.setOnPreferenceChangeListener(this);
 		layoutList.setOnPreferenceClickListener(this);
 
+		scanDelayPref = (ListPreference) findPreference("scan_delay_list_preference");
+		scanDelayPref.setOnPreferenceChangeListener(this);
 	}
 
 	@Override
@@ -89,9 +93,9 @@ public class MyPreferenceFragment extends PreferenceFragment implements
 		public int getVolume();
 
 		public void setVolume(int volume);
-		
+
 		public void setRemoteModel(boolean flag);
-		
+
 		public void readModelInfo();
 
 		public void readLayoutInfo();
@@ -107,7 +111,7 @@ public class MyPreferenceFragment extends PreferenceFragment implements
 			}else {
 				callbackSetting.setRemoteModel(false);
 			}
-			
+
 		}else if(preference == countryListPre){
 			if(newValue.equals("1")){
                 settings.edit().putInt("radioModel", RadioService.JAPAN_MODEL).commit();
@@ -168,6 +172,16 @@ public class MyPreferenceFragment extends PreferenceFragment implements
 				context.sendBroadcast(intent);
 				startActivity(intent);
 			}
+		} else if (preference == scanDelayPref) {
+			int secs;
+
+			try {
+				secs = Integer.parseInt(String.valueOf(newValue), 10);
+			} catch (NumberFormatException nfe) {
+				return false;
+			}
+
+			settings.edit().putInt("scanDelayMsecs", (int) (DateUtils.SECOND_IN_MILLIS * secs)).apply();
 		}
 		return true;
 	}
@@ -177,13 +191,13 @@ public class MyPreferenceFragment extends PreferenceFragment implements
 		// TODO Auto-generated method stub
 		return false;
 	}
-	
+
 	@Override
 	public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen,
 			Preference preference) {
 		// TODO Auto-generated method stub
 		if(preference == seekBarPreferences){
-			
+
 		}
 		return super.onPreferenceTreeClick(preferenceScreen, preference);
 	}

--- a/Radio/src/com/example/radio/RadioActivity.java
+++ b/Radio/src/com/example/radio/RadioActivity.java
@@ -5,9 +5,7 @@ import com.example.radio.RadioService.ChannelItem;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.graphics.ColorFilter;
 import android.media.AudioManager;
-import android.net.wifi.p2p.WifiP2pManager.Channel;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
@@ -15,7 +13,6 @@ import android.os.Message;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.app.AlertDialog.Builder;
 import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.content.BroadcastReceiver;
@@ -27,14 +24,12 @@ import android.content.IntentFilter;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
-import android.graphics.Color;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
-import android.view.Window;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
@@ -57,7 +52,7 @@ public class RadioActivity extends Activity implements
 	private static final int DISMISS_INPUT_DIALOG = 4;
 	private static final int VOLUME_DELAY_TIME = 3000;
 	private static final int CHANNEL_SIZE = 48;						//Channel娑擃亝鏆�
-	
+
 	private static int FOCUS_BUTTON_ID = 0;
 	private static int HEART_STATIC_FLAG = 0;
 
@@ -104,7 +99,7 @@ public class RadioActivity extends Activity implements
 	private Button mButtonButtonFm2;
 	private Button mButtonButtonAm;
 	private Button mButtonButtonSetting;
-	private Button mButtonButtoncollect;
+	private Button mButtonSaveToFavs;
 	private Button mButtonButtonHeart;
 	private Button mButtonClear;
 	private Button mButtonAddHeart;
@@ -118,18 +113,17 @@ public class RadioActivity extends Activity implements
 
 		serviceIntent = new Intent(getApplicationContext(), RadioService.class);
 		setupview();
-		
+
 		registerReceiver(myBroadcastReveiver, getIntentFilter());
 
-		radioService.isLive = true;
+		RadioService.isLive = true;
 		if(DEBUG) Log.d(TAG, "++++++onCreate()");
 	}
 
 	@SuppressWarnings("deprecation")
 	@Override
 	protected void onDestroy() {
-		// TODO Auto-generated method stub
-		radioService.isLive = false;
+		RadioService.isLive = false;
 		super.onDestroy();
 		if (mHandler != null) {
 			mHandler.removeMessages(UPDATE_CHANNEL_LIST);
@@ -140,7 +134,7 @@ public class RadioActivity extends Activity implements
 			removeDialog(DIALOG_SCAN);
 		}
 		this.unregisterReceiver(myBroadcastReveiver);
-		
+
 		//获取音频服务
 		AudioManager audioManager = (AudioManager) this.getSystemService(AUDIO_SERVICE);
 		//注册接收的Receiver
@@ -153,20 +147,18 @@ public class RadioActivity extends Activity implements
 
 	@Override
 	protected void onPause() {
-		// TODO Auto-generated method stub
 		super.onPause();
 		unbindService(this);
-				
+
 		if(DEBUG) Log.d(TAG, "++++++onPause()");
 	}
 
 	@Override
 	protected void onResume() {
-		// TODO Auto-generated method stub
 		super.onResume();
 		this.startService(serviceIntent);/* 閿熸枻鎷稲adioService閿熸枻鎷烽敓鏂ゆ嫹閿熸枻鎷烽敓鏂ゆ嫹 */
 		bindService(serviceIntent, this, BIND_AUTO_CREATE);
-		
+
 		//获取音频服务
 		AudioManager audioManager = (AudioManager) this.getSystemService(AUDIO_SERVICE);
 		//注册接收的Receiver
@@ -175,7 +167,7 @@ public class RadioActivity extends Activity implements
 				getPackageName(), MediaButtonIntentReceiver.class.getName());
 		//注册MediaButton
 		audioManager.registerMediaButtonEventReceiver(mRemoteControlClientReceiverComponent);
-				
+
 		if(DEBUG) Log.d(TAG, "++++++onResume()");
 	}
 
@@ -243,7 +235,7 @@ public class RadioActivity extends Activity implements
 				if (DEBUG)
 					Log.d(TAG, "btnauto has worked");
 				//showDialog(DIALOG_CONFIRM);
-				radioService.STEP_OR_AUTO = IS_AUTO_NOW;
+				RadioService.STEP_OR_AUTO = IS_AUTO_NOW;
 				new AlertDialog.Builder(RadioActivity.this)
 						.setTitle(R.string.remind)
 						.setCancelable(true)
@@ -254,7 +246,6 @@ public class RadioActivity extends Activity implements
 									@Override
 									public void onClick(DialogInterface dialog,
 											int which) {
-										// TODO Auto-generated method stub
 										for (int i = 0; i < CHANNEL_SIZE; i++) {
 											channelBtn[i].setText("");
 										}
@@ -263,27 +254,18 @@ public class RadioActivity extends Activity implements
 
 									}
 								})
-						.setNegativeButton(R.string.cancel,
-								new DialogInterface.OnClickListener() {
-
-									@Override
-									public void onClick(DialogInterface dialog,
-											int which) {
-										// TODO Auto-generated method stub
-
-									}
-								}).create().show();
+						.setNegativeButton(R.string.cancel, null).create().show();
 				break;
 			case R.id.btnsave:
 				int empty ,sameFreq ;
 				String curfreq = null;
 				int OUTSCOPE = 0 ,OUTSCOPE_FLAG = 1 ;
-				int START = 0,END = 0,END_EMPTY = 0; 
+				int START = 0,END = 0,END_EMPTY = 0;
 				if(radioService.getRadioType() == RadioService.RADIO_FM1){
 					// make the current freq type int to String
 					curfreq = Double.toString(radioService.getCurrentFreq()/100.0);
 					Log.v(TAG,"heart curfreq = "+curfreq+" CurrentFreq = "+radioService.getCurrentFreq());
-					
+
 					//if the freq's value outof the cur_Type. example: curfreq is 10390 ,but cur_Type is AM, 520~1710
 					if(radioService.getCurrentFreq() < RadioService.FM_LOW_FREQ || radioService.getCurrentFreq() > RadioService.FM_HIGH_FREQ){
 						OUTSCOPE = OUTSCOPE_FLAG;
@@ -322,12 +304,12 @@ public class RadioActivity extends Activity implements
 							//if freq is empty,save the i and assigned to empty
 							empty = i;
 							if(DEBUG)Log.v(TAG,"empty = " + empty);
-							
+
 							if(empty == END_EMPTY){
 								//if emty in the end ,show a toast to tell user
 								Toast.makeText(getApplicationContext(), R.string.nowhere, Toast.LENGTH_LONG).show();
 							}
-							
+
 							//add the curfreq into the empty channel and refresh view
 							ChannelItem item  ;
 							item = radioService.getChannelItem(empty);
@@ -335,17 +317,17 @@ public class RadioActivity extends Activity implements
 							item.name = curfreq;
 							radioService.setChannelItem(empty,item);
 							updateChannelList();
-							updateFreqView();	
-							
+							updateFreqView();
+
 							break;
 						} else if(radioService.getChannelItem(i).freq.equals(curfreq)){
-							//if curfreq == channel.freq, make a Toast 
+							//if curfreq == channel.freq, make a Toast
 							sameFreq = i;
 							Toast.makeText(getApplicationContext(), R.string.samefreq, Toast.LENGTH_SHORT).show();
 							if(DEBUG)Log.v(TAG,"sameFreq = " + sameFreq);
 							break;
 						}
-					}	
+					}
 				}
 				gone_Empty_ButtonView();
 				break;
@@ -360,7 +342,6 @@ public class RadioActivity extends Activity implements
 							@Override
 							public void onClick(DialogInterface dialog,
 									int which) {
-								// TODO Auto-generated method stub
 								Log.v(TAG,"1111111111");
 								clear_Single_Content();
 								Log.v(TAG,"2222222222");
@@ -370,16 +351,7 @@ public class RadioActivity extends Activity implements
 								updateFreqView();
 							}
 						})
-				.setNegativeButton(R.string.cancel,
-						new DialogInterface.OnClickListener() {
-
-							@Override
-							public void onClick(DialogInterface dialog,
-									int which) {
-								// TODO Auto-generated method stub
-
-							}
-						}).create().show();
+				.setNegativeButton(R.string.cancel, null).create().show();
 				break;
 			case R.id.btnfm1:
 				if (DEBUG)
@@ -411,7 +383,7 @@ public class RadioActivity extends Activity implements
 					updateFreqView();
 					radioSetSelect(RadioService.RADIO_AM);
 					gone_Empty_ButtonView();
-					
+
 				}else {
 					Toast.makeText(getApplicationContext(), R.string.searching, Toast.LENGTH_SHORT).show();
 				}
@@ -449,7 +421,7 @@ public class RadioActivity extends Activity implements
 					curFreq_Compare_To_Collect(radioService.getCurrentFreq());
 				} else {
 					radioService.stepRight(radioService.getCurrentFreq());
-					radioService.STEP_OR_AUTO = IS_STEP_NOW;
+					RadioService.STEP_OR_AUTO = IS_STEP_NOW;
 				}
 				break;
 			case R.id.btnbackward:
@@ -458,7 +430,7 @@ public class RadioActivity extends Activity implements
 					curFreq_Compare_To_Collect(radioService.getCurrentFreq());
 				} else {
 					radioService.stepLeft(radioService.getCurrentFreq());
-					radioService.STEP_OR_AUTO = IS_STEP_NOW;
+					RadioService.STEP_OR_AUTO = IS_STEP_NOW;
 				}
 				break;
 			case R.id.channel0:
@@ -509,7 +481,7 @@ public class RadioActivity extends Activity implements
 			case R.id.channel45:
 			case R.id.channel46:
 			case R.id.channel47:
-						
+
 				setChannelChecked(what - R.id.channel0);
 
 				break;
@@ -611,13 +583,13 @@ public class RadioActivity extends Activity implements
 			LayoutInflater lauoutInflater = LayoutInflater.from(RadioActivity.this);
 			checkbox = lauoutInflater.inflate(R.layout.checkbox, null);
 			cBox = (CheckBox) checkbox.findViewById(R.id.check);
-			
+
 			SharedPreferences pre = getSharedPreferences("checkvalue", MODE_PRIVATE);
 			String value = pre.getString("ischeck", "");
 			/*****if check the NO_Remind,the Dialog no show next time******/
 			if (value.endsWith("1")) {
 				createDialog().dismiss();
-				
+
 				//clear all content and refresh view
 				radioService.clearAllContent();
 				gone_Empty_ButtonView();
@@ -660,9 +632,9 @@ public class RadioActivity extends Activity implements
 		mMiddleButtonStep = (Button) findViewById(R.id.btnstep);
 		mMiddleButtonStep.setOnClickListener(this);
 		mMiddleButtonAuto = (Button) findViewById(R.id.btnauto);
-		mMiddleButtonAuto.setOnClickListener(this);		
-		mButtonButtoncollect = (Button)findViewById(R.id.collect);
-		mButtonButtoncollect.setOnClickListener(this);
+		mMiddleButtonAuto.setOnClickListener(this);
+		mButtonSaveToFavs = (Button)findViewById(R.id.collect);
+		mButtonSaveToFavs.setOnClickListener(this);
 		mButtonButtonHeart = (Button) findViewById(R.id.btnsave);
 		mButtonButtonHeart.setOnClickListener(this);
 		mButtonClear = (Button) findViewById(R.id.btnclear);
@@ -719,8 +691,8 @@ public class RadioActivity extends Activity implements
 		channelBtn[45] = (Button) findViewById(R.id.channel45);
 		channelBtn[46] = (Button) findViewById(R.id.channel46);
 		channelBtn[47] = (Button) findViewById(R.id.channel47);
-		
-		
+
+
 		for (int i = 0; i < CHANNEL_SIZE; i++) {
 			channelBtn[i].setOnClickListener(this);
 			channelBtn[i].setOnLongClickListener(this);
@@ -731,7 +703,6 @@ public class RadioActivity extends Activity implements
 
 		@Override
 		public void onStatusChange(int type) {
-			// TODO Auto-generated method stub
 			Message msg = mHandler.obtainMessage(type);
 			mHandler.sendMessage(msg);
 		}
@@ -741,8 +712,7 @@ public class RadioActivity extends Activity implements
 	 * Removing a single Button
 	 * */
 	public void clear_Single_Content() {
-		// TODO Auto-generated method stub
-		if (radioService.getRadioType() == radioService.RADIO_FM1 || radioService.getRadioType() == radioService.RADIO_FM2) {
+		if (radioService.getRadioType() == RadioInterface.RADIO_FM1 || radioService.getRadioType() == RadioInterface.RADIO_FM2) {
 
 				ChannelItem item = new ChannelItem();
 				item.freq = "";
@@ -753,7 +723,7 @@ public class RadioActivity extends Activity implements
 					radioService.setChannelItem(FOCUS_BUTTON_ID, item);
 				}
 
-		} else if (radioService.getRadioType() == radioService.RADIO_AM) {
+		} else if (radioService.getRadioType() == RadioInterface.RADIO_AM) {
 				ChannelItem item = new ChannelItem();
 				item.freq = "";
 				item.name = "";
@@ -761,7 +731,7 @@ public class RadioActivity extends Activity implements
 				if(channelBtn[FOCUS_BUTTON_ID].isSelected()){
 					radioService.setChannelItem(FOCUS_BUTTON_ID + 48, item);
 				}
-		} else if(radioService.getRadioType() == radioService.RADIO_COLLECT){
+		} else if(radioService.getRadioType() == RadioInterface.RADIO_COLLECT){
 				ChannelItem item = new ChannelItem();
 				item.freq = "";
 				item.name = "";
@@ -775,19 +745,18 @@ public class RadioActivity extends Activity implements
 		mButtonAddHeart.setBackground(getResources().getDrawable(R.drawable.btncollect_heart));
 		/*******************************************************************************************/
 	}
-	
+
 	/**
 	 * 末尾Channel信息为空时 隐藏其界面
 	 */
 	private void gone_Empty_ButtonView() {
-		// TODO Auto-generated method stub
 		ChannelItem item;
 		for(int j=0; j<48; j++){
 			channelBtn[j].setVisibility(View.VISIBLE);
 		}
 		updateChannelList();
 		updateFreqView();
-		if(radioService.getRadioType() == radioService.RADIO_FM1){
+		if(radioService.getRadioType() == RadioInterface.RADIO_FM1){
 			int i = 47;
 			int gone_ID = 0;
 			for(; i>0; i--){
@@ -801,11 +770,11 @@ public class RadioActivity extends Activity implements
 			}else {
 				gone_ID = 12;
 			}
-			
+
 			for(; gone_ID<48; gone_ID++){
 				channelBtn[gone_ID].setVisibility(View.GONE);
 			}
-		}else if (radioService.getRadioType() == radioService.RADIO_AM) {
+		}else if (radioService.getRadioType() == RadioInterface.RADIO_AM) {
 			int i = 95;
 			int gone_ID = 0;
 			for(; i>48; i--){
@@ -814,7 +783,7 @@ public class RadioActivity extends Activity implements
 					break;
 				}
 			}
-			
+
 			if((i-47)>=12){
 				gone_ID = i-47;
 			}else {
@@ -823,7 +792,7 @@ public class RadioActivity extends Activity implements
 			for(; gone_ID<48; gone_ID++){
 				channelBtn[gone_ID].setVisibility(View.GONE);
 			}
-		}else if (radioService.getRadioType() == radioService.RADIO_COLLECT) {
+		}else if (radioService.getRadioType() == RadioInterface.RADIO_COLLECT) {
 			int i = 143;
 			int gone_ID = 0;
 			for(; i>96; i--){
@@ -842,12 +811,12 @@ public class RadioActivity extends Activity implements
 			}
 		}
 	}
-	
+
 	public void setChannelChecked(int btnId) {
 		int checkedId = 0;
-		
+
 		ChannelItem item;
-		
+
 		if (DEBUG)
 			Log.v(TAG, "setChannelChecked is into here,btnId = "+btnId);
 		//checkedID's scope 0 ~ RADIO_CHANNEL_COUNT
@@ -864,7 +833,7 @@ public class RadioActivity extends Activity implements
 				Log.v(TAG, "item.freq is empty!!!");
 			return;
 		}
-		
+
 		if (radioService.getRadioType() == RadioService.RADIO_COLLECT) {
 			//******** If Typ is RADIO_COLLECT,According to the frequency of judgment //
 			//******** whether FM or AM												  //
@@ -900,7 +869,7 @@ public class RadioActivity extends Activity implements
 						.replaceAll("\\.", "")));
 			}
 		}
-		
+
 
 		for (int i = 0; i < RadioService.RADIO_PAGE_COUNT; i++) {
 			if (channelBtn[i].isSelected()) {
@@ -936,7 +905,6 @@ public class RadioActivity extends Activity implements
 	@Override
 	// 閿熸枻鎷稲adioService閿熸枻鎷烽敓鏂ゆ嫹閿熸枻鎷烽敓鏂ゆ嫹
 	public void onServiceConnected(ComponentName name, IBinder service) {
-		// TODO Auto-generated method stub
 		if (DEBUG)
 			Log.v(TAG, "RadioService is connected");
 		radioService = ((RadioService.ServiceBinder) service).getService();
@@ -1003,28 +971,27 @@ public class RadioActivity extends Activity implements
 			mButtonButtonFm1.setSelected(true);
 			//mButtonButtonFm2.setSelected(false);
 			mButtonButtonAm.setSelected(false);
-			mButtonButtoncollect.setSelected(false);
+			mButtonSaveToFavs.setSelected(false);
 		} else if (RadioService.RADIO_COLLECT == radioService.getRadioType()) {
 			((TextView) findViewById(R.id.radiotype)).setText("FAV"); /* 閿熸枻鎷稦M2鏃秚ext閿熺殕璁规嫹閿熷彨浼欐嫹閿熸枻鎷锋伅 */
 			((TextView) findViewById(R.id.radiohz)).setText(" ");
 			mButtonButtonFm1.setSelected(false);
 			//mButtonButtonFm2.setSelected(true);
 			mButtonButtonAm.setSelected(false);
-			mButtonButtoncollect.setSelected(true);
+			mButtonSaveToFavs.setSelected(true);
 		} else if (RadioService.RADIO_AM == radioService.getRadioType()) {
 			((TextView) findViewById(R.id.radiotype)).setText("AM"); /* 閿熸枻鎷稟M鏃秚ext閿熺殕璁规嫹閿熷彨浼欐嫹閿熸枻鎷锋伅 */
 			((TextView) findViewById(R.id.radiohz)).setText("KHz");
 			mButtonButtonFm1.setSelected(false);
 			//mButtonButtonFm2.setSelected(false);
 			mButtonButtonAm.setSelected(true);
-			mButtonButtoncollect.setSelected(false);
+			mButtonSaveToFavs.setSelected(false);
 		}
 		updateChannelList();
 	}
 
 	@Override
 	public void onServiceDisconnected(ComponentName name) {
-		// TODO Auto-generated method stub
 		if(DEBUG) Log.v(TAG, "RadioService is disconnected");
 		radioService = null;
 	}
@@ -1038,37 +1005,37 @@ public class RadioActivity extends Activity implements
 			mButtonButtonFm1.setSelected(true);
 			//mButtonButtonFm2.setSelected(false);
 			mButtonButtonAm.setSelected(false);
-			mButtonButtoncollect.setSelected(false);
-			
+			mButtonSaveToFavs.setSelected(false);
+
 			if(radioService.getCurChannelId() >= 96 && radioService.getCurChannelId() < 144){
 				//If focus in the RADIO_COLLECT Type,No need turnFMAM
 			}else {
 				radioService.turnFmAm(0);
 			}
-			
+
 		} else if (RadioService.RADIO_COLLECT == type) {
 			((TextView) findViewById(R.id.radiotype)).setText("FAV"); /* 閿熸枻鎷稦M2鏃秚ext閿熺殕璁规嫹閿熷彨浼欐嫹閿熸枻鎷锋伅 */
 			((TextView) findViewById(R.id.radiohz)).setText(" ");
 			mButtonButtonFm1.setSelected(false);
 			//mButtonButtonFm2.setSelected(false);
 			mButtonButtonAm.setSelected(false);
-			mButtonButtoncollect.setSelected(true);
-			
+			mButtonSaveToFavs.setSelected(true);
+
 		} else if (RadioService.RADIO_AM == type) {
 			((TextView) findViewById(R.id.radiotype)).setText("AM"); /* 閿熸枻鎷稟M鏃秚ext閿熺殕璁规嫹閿熷彨浼欐嫹閿熸枻鎷锋伅 */
 			((TextView) findViewById(R.id.radiohz)).setText("kHz");
 			mButtonButtonFm1.setSelected(false);
 			//mButtonButtonFm2.setSelected(false);
 			mButtonButtonAm.setSelected(true);
-			mButtonButtoncollect.setSelected(false);
+			mButtonSaveToFavs.setSelected(false);
 
 			if(radioService.getCurChannelId() >= 96 && radioService.getCurChannelId() < 144){
 				//If focus in the RADIO_COLLECT Type,No need turnFMAM
 			}else {
 				radioService.turnFmAm(1);
 			}
-			
-		} 
+
+		}
 		updateChannelList();
 
 	}
@@ -1076,7 +1043,6 @@ public class RadioActivity extends Activity implements
 	@Override
 	// 閿熸枻鎷烽敓閰电鎷烽敓鏂ゆ嫹閿熻緝顤庢嫹閿熺丹Handler閿熸枻鎷烽敓鏂ゆ嫹
 	public void onClick(View v) {
-		// TODO Auto-generated method stub
 		int viewId = v.getId();
 		Message msg = mHandler.obtainMessage(viewId);
 		if (msg != null) {
@@ -1088,7 +1054,7 @@ public class RadioActivity extends Activity implements
 		int counter;
 		int tempFreq;
 		int channelID = -1;
-		for (counter = 0; counter < radioService.RADIO_CHANNEL_COUNT; counter++) {
+		for (counter = 0; counter < RadioService.RADIO_CHANNEL_COUNT; counter++) {
 			ChannelItem item;
 			tempFreq = 0;
 			item = radioService.getChannelItem(counter);
@@ -1244,7 +1210,7 @@ public class RadioActivity extends Activity implements
 			}
 		}
 		/*****setChannelText ,If abridge is not NULL ,set abridge.Otherwise set freq****/
-		for (int i = 0; i < RadioService.RADIO_PAGE_COUNT; i++) { 
+		for (int i = 0; i < RadioService.RADIO_PAGE_COUNT; i++) {
 			item = radioService.getChannelItem(i + offset);
 			if (item.abridge != null && !item.abridge.equals("")) {
 				channelBtn[i].setText(item.abridge);
@@ -1253,7 +1219,7 @@ public class RadioActivity extends Activity implements
 			}
 		}
 		/*******************************************************************************/
-		
+
 		// view the select mode
 		for (int i = 0; i < RadioService.RADIO_PAGE_COUNT; i++) {
 			if (pressedId == i && pressedId < RadioService.RADIO_PAGE_COUNT) {
@@ -1265,7 +1231,7 @@ public class RadioActivity extends Activity implements
 					}else if (i >= RadioService.RADIO_FM_COUNT && i < RadioService.RADIO_PAGE_COUNT) {
 						channelBtn[i].setSelected(false);
 					}
-					
+
 				}else {
 					channelBtn[pressedId].setSelected(true);
 				}
@@ -1276,14 +1242,13 @@ public class RadioActivity extends Activity implements
 			} else if (channelBtn[i].isSelected()) {
 				channelBtn[i].setSelected(false);
 			}
-		}	
+		}
 		flag = 0 ;
 	}
 
 	@Override
 	@Deprecated
 	protected Dialog onCreateDialog(int id) {
-		// TODO Auto-generated method stub
 		if (DEBUG)
 			Log.d(TAG, "onCreateDialog is open");
 		switch (id) {
@@ -1438,7 +1403,6 @@ public class RadioActivity extends Activity implements
 								@Override
 								public void onClick(DialogInterface dialog,
 										int which) {
-									// TODO Auto-generated method stub
 									freqEdit.setText("");
 									freqEdit.setSelection(freqEdit.length());
 									shortNameEdit.setText("");
@@ -1522,17 +1486,16 @@ public class RadioActivity extends Activity implements
 	@Override
 	public void onStopTrackingTouch(SeekBar seekBar) {
 	}
-	
+
 	@Override
 	public boolean onKeyDown(int keyCode, KeyEvent event) {
-		// TODO Auto-generated method stub
-		if (keyCode == KeyEvent.KEYCODE_BACK) {  
-            moveTaskToBack(false);  
-            return true;  
-        }  
+		if (keyCode == KeyEvent.KEYCODE_BACK) {
+            moveTaskToBack(false);
+            return true;
+        }
 		return super.onKeyDown(keyCode, event);
 	}
-	
+
 	/*************The No_Remind Dialog*******************/
 	private AlertDialog createDialog() {
 		di = new AlertDialog.Builder(this).setTitle("温馨提示")
@@ -1554,31 +1517,21 @@ public class RadioActivity extends Activity implements
 						gone_Empty_ButtonView();
 						updateChannelList();
 						updateFreqView();
-						
+
 						editor.commit();
 
 					}
-				}).setNegativeButton(R.string.cancel,
-						new DialogInterface.OnClickListener() {
-
-							@Override
-							public void onClick(DialogInterface dialog,
-									int which) {
-								// TODO Auto-generated method stub
-							}
-						})
-				
+				}).setNegativeButton(R.string.cancel, null)
 				.create();
 		return di;
 	}
-	
+
 	/**
 	 * @return 返回48~0个Button中第一个有效信息的Button ID号
 	 */
 	private int last_Effective_ChannelItem() {
-		// TODO Auto-generated method stub
 		ChannelItem item;
-		if(radioService.getRadioType() == radioService.RADIO_FM1){
+		if(radioService.getRadioType() == RadioInterface.RADIO_FM1){
 			int id = 47;
 			for(; id>0; id--){
 				item = radioService.getChannelItem(id);
@@ -1586,7 +1539,7 @@ public class RadioActivity extends Activity implements
 					return id;
 				}
 			}
-		}else if (radioService.getRadioType() == radioService.RADIO_AM) {
+		}else if (radioService.getRadioType() == RadioInterface.RADIO_AM) {
 			int id = 95;
 			for(; id>48; id--){
 				item = radioService.getChannelItem(id);
@@ -1594,7 +1547,7 @@ public class RadioActivity extends Activity implements
 					return id;
 				}
 			}
-		}else if (radioService.getRadioType() == radioService.RADIO_COLLECT) {
+		}else if (radioService.getRadioType() == RadioInterface.RADIO_COLLECT) {
 			int id = 143;
 			for(; id>96; id--){
 				item = radioService.getChannelItem(id);
@@ -1605,14 +1558,14 @@ public class RadioActivity extends Activity implements
 		}
 		return 0;
 	}
-	
+
 	/**
 	 * @param id 遇见的item.freq为空时的id（可以大于48）
 	 * @return 返回id~各自Type结尾channelID 第一个有效 id(可以大于48，所以注意返回值要小于48，需要做转换)
 	 */
 	private int first_Effective_ChannelItem(int id){
 		ChannelItem item;
-		if(radioService.getRadioType() == radioService.RADIO_FM1){
+		if(radioService.getRadioType() == RadioInterface.RADIO_FM1){
 			if(id < 0){
 				id = first_Effective_ChannelItem_For_Lastsong();
 			}
@@ -1622,7 +1575,7 @@ public class RadioActivity extends Activity implements
 					return id;
 				}
 			}
-		}else if (radioService.getRadioType() == radioService.RADIO_AM) {
+		}else if (radioService.getRadioType() == RadioInterface.RADIO_AM) {
 			if(id < 48){
 				id = first_Effective_ChannelItem_For_Lastsong();
 			}
@@ -1632,7 +1585,7 @@ public class RadioActivity extends Activity implements
 					return id - 48;
 				}
 			}
-		}else if (radioService.getRadioType() == radioService.RADIO_COLLECT) {
+		}else if (radioService.getRadioType() == RadioInterface.RADIO_COLLECT) {
 			if(id < 96){
 				id = first_Effective_ChannelItem_For_Lastsong();
 			}
@@ -1687,7 +1640,7 @@ public class RadioActivity extends Activity implements
 			setChannelChecked(checkedId + 1);
 		}
 	}
-	
+
 	/**
 	 * @param id 遇见的item.freq为空时的id（可以大于48）
 	 * @return 返回id~各自Type起始channelID内第一个有效 id(可以大于48，所以注意返回值要小于48，需要做转换)
@@ -1695,21 +1648,21 @@ public class RadioActivity extends Activity implements
 	private int last_Effective_ChannelItem_For_Lastsong(int id){
 		ChannelItem item;
 		int startId = id;
-		if(radioService.getRadioType() == radioService.RADIO_FM1){
+		if(radioService.getRadioType() == RadioInterface.RADIO_FM1){
 			for( ;startId>0; startId--){
 				item = radioService.getChannelItem(startId);
 				if(!item.freq.equals("")){
 					return startId;
 				}
 			}
-		}else if (radioService.getRadioType() == radioService.RADIO_AM) {
+		}else if (radioService.getRadioType() == RadioInterface.RADIO_AM) {
 			for(; startId>48; startId--){
 				item = radioService.getChannelItem(startId);
 				if(!item.freq.equals("")){
 					return startId - 48;
 				}
 			}
-		}else if (radioService.getRadioType() == radioService.RADIO_COLLECT) {
+		}else if (radioService.getRadioType() == RadioInterface.RADIO_COLLECT) {
 			for(; startId>96; startId--){
 				item = radioService.getChannelItem(startId);
 				if(!item.freq.equals("")){
@@ -1719,14 +1672,13 @@ public class RadioActivity extends Activity implements
 		}
 		return 0;
 	}
-	
+
 	/**
 	 * 各自Type：0~48 中第一个有效频道ID
 	 */
 	private int first_Effective_ChannelItem_For_Lastsong() {
-		// TODO Auto-generated method stub
 		ChannelItem item;
-		if(radioService.getRadioType() == radioService.RADIO_FM1){
+		if(radioService.getRadioType() == RadioInterface.RADIO_FM1){
 			int id = 0 ;
 			for(; id<48; id++){
 				item = radioService.getChannelItem(id);
@@ -1734,7 +1686,7 @@ public class RadioActivity extends Activity implements
 					return id;
 				}
 			}
-		}else if (radioService.getRadioType() == radioService.RADIO_AM) {
+		}else if (radioService.getRadioType() == RadioInterface.RADIO_AM) {
 			int id = 48;
 			for(; id<96; id++){
 				item = radioService.getChannelItem(id);
@@ -1742,7 +1694,7 @@ public class RadioActivity extends Activity implements
 					return id - 48;
 				}
 			}
-		}else if (radioService.getRadioType() == radioService.RADIO_COLLECT) {
+		}else if (radioService.getRadioType() == RadioInterface.RADIO_COLLECT) {
 			int id = 96;
 			for(; id<144; id++){
 				item = radioService.getChannelItem(id);
@@ -1753,7 +1705,7 @@ public class RadioActivity extends Activity implements
 		}
 		return 0;
 	}
-	
+
 	public void lastSong() {
 		int checkedId = 0;
 		ChannelItem item;
@@ -1769,7 +1721,7 @@ public class RadioActivity extends Activity implements
 			}else if(curChannel + 1 >48){
 				checkedId = first_Effective_ChannelItem_For_Lastsong();
 			}
-			
+
 			if (checkedId < 0) {
 				checkedId = 0;
 			}
@@ -1782,7 +1734,7 @@ public class RadioActivity extends Activity implements
 			}else if(curChannel + 1 >96){
 				checkedId = first_Effective_ChannelItem_For_Lastsong();
 			}
-			
+
 			if (checkedId < 0) {
 				checkedId = 1;
 			}
@@ -1795,7 +1747,7 @@ public class RadioActivity extends Activity implements
 			}else if(curChannel + 1 >144){
 				checkedId = first_Effective_ChannelItem_For_Lastsong();
 			}
-			
+
 			if (checkedId < 0) {
 				checkedId = 0;
 			}
@@ -1805,7 +1757,7 @@ public class RadioActivity extends Activity implements
 		}else {
 			item = radioService.getChannelItem(curChannel - 1);
 		}
-		
+
 		Log.v(TAG, "first_Effective_ChannelItem_For_Lastsong = --->" + first_Effective_ChannelItem_For_Lastsong()+" |curChannel = "+curChannel+" |checkedId = "+checkedId);
 		if(curId == first_Effective_ChannelItem_For_Lastsong()){
 			Log.v(TAG, "33333333333effective_id = "+effective_id);
@@ -1832,9 +1784,9 @@ public class RadioActivity extends Activity implements
 				setChannelChecked(checkedId - 1);
 			}
 		}
-		
+
 	}
-	
+
 	/**
 	 * 爱心Btn功能
 	 */
@@ -1853,7 +1805,7 @@ public class RadioActivity extends Activity implements
 					curfreq = Double.toString(radioService.getCurrentFreq()/100.0);
 					focus_btn = FOCUS_BUTTON_ID;
 					Log.v(TAG,"heart curfreq = "+curfreq+" CurrentFreq = "+radioService.getCurrentFreq());
-					
+
 					//if the freq's value outof the cur_Type. example: curfreq is 10390 ,but cur_Type is AM, 520~1710
 					if(radioService.getCurrentFreq() < RadioService.FM_LOW_FREQ || radioService.getCurrentFreq() > RadioService.FM_HIGH_FREQ){
 						OUTSCOPE = OUTSCOPE_FLAG;
@@ -1894,16 +1846,16 @@ public class RadioActivity extends Activity implements
 							//if freq is empty,save the i and assigned to empty
 							empty = i;
 							if(DEBUG)Log.v(TAG,"empty = " + empty);
-							
+
 							if(empty == END_EMPTY){
 								//if emty in the end ,show a toast to tell user
 								Toast.makeText(getApplicationContext(), R.string.nowhere, Toast.LENGTH_LONG).show();
 							}
-							
+
 							//add the curfreq into the empty channel and refresh view
 							ChannelItem item  ;
 							item = radioService.getChannelItem(empty);
-							
+
 							/**************当前频率与焦点频率相同时,加入收藏栏的频率为焦点中文名
 							 **************若不同时,则收藏栏显示频率值***********************/
 							Log.v(TAG, "*******************CurrentFreq ="+radioService.getCurrentFreq()+" |item.freq="+radioService.getChannelItem(focus_btn).freq);
@@ -1928,19 +1880,19 @@ public class RadioActivity extends Activity implements
 							}else {
 								Toast.makeText(getApplicationContext(), R.string.not_effective_freq, Toast.LENGTH_SHORT).show();
 							}
-							
+
 							/************************************************************/
-							
-							
+
+
 							break;
 						} else if(radioService.getChannelItem(i).freq.equals(curfreq)){
-							//if curfreq == channel.freq, make a Toast 
+							//if curfreq == channel.freq, make a Toast
 							sameFreq = i;
 							Toast.makeText(getApplicationContext(), R.string.same_addHeart_toast, Toast.LENGTH_SHORT).show();
 							if(DEBUG)Log.v(TAG,"sameFreq = " + sameFreq);
 							break;
 						}
-					}	
+					}
 				}
 			}else if (HEART_STATIC_FLAG == 1) {
 				//全局变量为1,说明当前焦点频率在收藏栏中存在,再次点击爱心按钮,则变为取消收藏功能,且爱心变为空心
@@ -1972,9 +1924,9 @@ public class RadioActivity extends Activity implements
 		}else {
 			Toast.makeText(getApplicationContext(), R.string.not_effective_freq, Toast.LENGTH_SHORT).show();
 		}
-		
+
 	}
-	
+
 	/**
 	 * @param curFreq
 	 * 当前频率值与收藏栏的频率值作比较,若收藏栏存在当前频率值
@@ -1982,7 +1934,6 @@ public class RadioActivity extends Activity implements
 	 */
 	private void curFreq_Compare_To_Collect(int curFreq) {
 		Log.v(TAG, "curFreq_Compare_To_Collect");
-		// TODO Auto-generated method stub
 		//int curFreq = radioService.getCurrentFreq();
 		Log.v(TAG, "curFreq_Compare_To_Collect-----curFreq="+curFreq);
 		int collect_Freq = 0;
@@ -1997,7 +1948,7 @@ public class RadioActivity extends Activity implements
 			}else if(!item.freq.equals("")){
 				collect_Freq = Integer.parseInt(item.freq);
 			}
-			
+
 			if(collect_Freq == curFreq){
 				HEART_STATIC_FLAG = 1;
 				mButtonAddHeart.setBackground(getResources().getDrawable(R.drawable.collect_d));
@@ -2005,8 +1956,8 @@ public class RadioActivity extends Activity implements
 			}
 		}
 	}
-	
-	private IntentFilter getIntentFilter(){		
+
+	private IntentFilter getIntentFilter(){
 		IntentFilter myIntentFilter = new IntentFilter("Auto-Search");
 		myIntentFilter.addAction("Radio.Media_Broadcast_Next");
 		myIntentFilter.addAction("Radio.Media_Broadcast_Last");
@@ -2017,14 +1968,13 @@ public class RadioActivity extends Activity implements
 		myIntentFilter.addAction("updateLayoutView");
 		myIntentFilter.addAction("MediaStatus.BonovoRadio.Media_Broadcast_Close");
 		return myIntentFilter;
-		
+
 	};
-	
+
 	private BroadcastReceiver myBroadcastReveiver = new BroadcastReceiver() {
-		
+
 		@Override
 		public void onReceive(Context context, Intent intent) {
-			// TODO Auto-generated method stub
 			/************ 娣囨繂鐡ㄩ懛顏勫З閹兼粎鍌ㄩ幖婊冨煂閻ㄥ嫬褰� *************/
 			if (intent.getAction().equals("Auto-Search")) {
 				int iCurfreq = intent.getIntExtra("auto-curfreq", 0);
@@ -2076,7 +2026,7 @@ public class RadioActivity extends Activity implements
 						item.name = "";
 						radioService.setChannelItem(nIdex, item);
 					}
-					
+
 					mHandler.sendEmptyMessage(UPDATE_CHANNEL_LIST);
 					updateFreqView();
 				}
@@ -2091,8 +2041,8 @@ public class RadioActivity extends Activity implements
 			} else if (intent.getAction().equals(
 					"android.intent.action.BONOVO_SWITCH_FMAM")) {
 				Log.v(TAG, "BONOVO_SWITCH_FMAM");
-				if (radioService.getRadioType() == radioService.RADIO_FM1
-						|| radioService.getRadioType() == radioService.RADIO_FM2) {
+				if (radioService.getRadioType() == RadioInterface.RADIO_FM1
+						|| radioService.getRadioType() == RadioInterface.RADIO_FM2) {
 					if (!radioService.mIsSearchThreadRunning) {
 						updateFreqView();
 						radioSetSelect(RadioService.RADIO_AM);

--- a/Radio/src/com/example/radio/RadioActivity.java
+++ b/Radio/src/com/example/radio/RadioActivity.java
@@ -24,6 +24,7 @@ import android.content.IntentFilter;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
+import android.text.format.DateUtils;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -52,8 +53,6 @@ public class RadioActivity extends Activity implements
 	private static final int DISMISS_INPUT_DIALOG = 4;
 	private static final int VOLUME_DELAY_TIME = 3000;
 	private static final int CHANNEL_SIZE = 48;						//Channel娑擃亝鏆�
-
-	private static final long DELAY_SCAN_SEEK = 3000;
 
 	private static int FOCUS_BUTTON_ID = 0;
 	private static int HEART_STATIC_FLAG = 0;
@@ -521,7 +520,7 @@ public class RadioActivity extends Activity implements
 					stopScan();
 				} else {
 					radioService.stepRight(radioService.getCurrentFreq());
-					mHandler.postDelayed(this, DELAY_SCAN_SEEK);
+					mHandler.postDelayed(this, radioService.getScanDelayMs());
 				}
 			} else {
 				Toast.makeText(RadioActivity.this, "Not scanning, current function=" + radioService.getFunctionId(), Toast.LENGTH_SHORT).show();
@@ -544,7 +543,7 @@ public class RadioActivity extends Activity implements
 			mMiddleButtonStep.setText(R.string.scanning);
 			radioService.setFunctionId(RadioInterface.FUNCTION_SCAN);
 			radioService.stepRight(radioService.getCurrentFreq());
-			mHandler.postDelayed(mScanRunnable, DELAY_SCAN_SEEK);
+			mHandler.postDelayed(mScanRunnable, radioService.getScanDelayMs());
 		} else {
 			Log.i(TAG, "NOT starting scan, because function=" + radioService.getFunctionId());
 		}
@@ -2144,6 +2143,8 @@ public class RadioActivity extends Activity implements
 				radioService.stopService(new Intent("com.example.radio.RadioService"));
 
 				finish();
+			} else if (intent.getAction().equals("Radio.scanDelayUpdated")) {
+
 			}
 		}
 	};

--- a/Radio/src/com/example/radio/RadioInterface.java
+++ b/Radio/src/com/example/radio/RadioInterface.java
@@ -6,6 +6,11 @@ public interface RadioInterface {
 	public static final int RADIO_FM2 = 1;
 	public static final int RADIO_AM = 2;
 	public static final int RADIO_COLLECT = 3;
+
+	int FUNCTION_FINE_TUNE = 0;
+	int FUNCTION_STEP_SEEK = 1;
+	int FUNCTION_SCAN = 2;
+
 	//��JNI�йصĺ���
 	public int fineLeft(int freq);
 	public int fineRight(int freq);
@@ -13,7 +18,7 @@ public interface RadioInterface {
 	public int stepRight(int freq);
 	public void setFreq(int freq);
     public void onAutoSearch();
-    
+
 	int getCurChannelId();
     void setCurChannelId(int id);
 	void setFunctionId(int id);
@@ -21,7 +26,7 @@ public interface RadioInterface {
 	void setCurrentFreq(int freq);
 	int getCurrentFreq();
 	void clearAllContent();
-	
+
 	//����ӿ�
 	interface RadioStatusChangeListener {
 	      public void onStatusChange(int type);

--- a/Radio/src/com/example/radio/RadioService.java
+++ b/Radio/src/com/example/radio/RadioService.java
@@ -1399,6 +1399,11 @@ public class RadioService extends Service implements RadioInterface,
         return RADIO_LAYOUT;
     }
 
+	public int getScanDelayMs() {
+		// Default delay = 3 seconds
+		return settings.getInt("scanDelayMsecs", 3000);
+	}
+
     public void setCustomColors(int alpha, int red, int green, int blue, int brightness, int contrast, int saturation, int hue) {
         SharedPreferences.Editor editor = settings.edit();
         editor.putInt("alpha", alpha);

--- a/Radio/src/com/example/radio/RadioService.java
+++ b/Radio/src/com/example/radio/RadioService.java
@@ -73,6 +73,7 @@ public class RadioService extends Service implements RadioInterface,
         }
         return 0;
     }
+
 	public static final String MSG_CLOSE = "com.example.radioplayer.close";
 	private static final String TAG = "RadioService";
 	private static final String APPLICATIONS = "applications";
@@ -221,7 +222,6 @@ public class RadioService extends Service implements RadioInterface,
 
 	@Override
 	public IBinder onBind(Intent intent) {
-		// TODO Auto-generated method stub
 		if(DEBUG) Log.v(TAG, "------onBind()");
 
 		return serviceBinder;
@@ -229,7 +229,6 @@ public class RadioService extends Service implements RadioInterface,
 
 	@Override
 	public boolean onUnbind(Intent intent) {
-		// TODO Auto-generated method stub
 		if (DEBUG)
 			Log.d(TAG, "------onUnbind()");
 		return super.onUnbind(intent);
@@ -239,7 +238,6 @@ public class RadioService extends Service implements RadioInterface,
     private RadioPlayerStatusStore mRadioPlayerStatusStore;
 	@Override
 	public void onCreate() {
-		// TODO Auto-generated method stub
 		super.onCreate();
 		mContext = this;
         mCanRadio = new CanRadio(this);
@@ -255,7 +253,7 @@ public class RadioService extends Service implements RadioInterface,
 			readAndSetModelInfo();
 			updatePreferences(RADIO_DATA_READ);
 		}
-		
+
 		if(DEBUG) Log.d(TAG, "------onCreate()");
 		PowerOnOff(true); // open radio
 				if (DEBUG)
@@ -308,7 +306,6 @@ public class RadioService extends Service implements RadioInterface,
 
 	@Override
 	public void onDestroy() {
-		// TODO Auto-generated method stub
 		super.onDestroy();
 		stopForeground(false);
 		if(DEBUG) Log.d(TAG, "------onDestroy()");
@@ -357,7 +354,6 @@ public class RadioService extends Service implements RadioInterface,
 
 		@Override
 		public void run() {
-			// TODO Auto-generated method stub
 			int res, status = RADIO_START_SEARCH;
 			int idex = 0;
 			if (DEBUG)
@@ -389,14 +385,14 @@ public class RadioService extends Service implements RadioInterface,
 							curFreq = freq[2]; // 自动搜到的台的频率
 							Log.d(TAG,"@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@curFreq(FLAG Auto) ="+ curFreq);
 							int autoFreq;
-							
+
 							autoFreq = curFreq;
 							if(getRadioType() == RADIO_FM1){
 								mCanRadio.sendRadioInfo(CanRadio.BAND_FM, curFreq);
 							}else if (getRadioType() == RADIO_AM) {
 								mCanRadio.sendRadioInfo(CanRadio.BAND_AM, curFreq);
 							}
-							
+
 							Intent it = new Intent();
 							Bundle mbundle = new Bundle();
 							mbundle.putInt("auto-curfreq", autoFreq);
@@ -405,7 +401,7 @@ public class RadioService extends Service implements RadioInterface,
 							it.setAction("Auto-Search");
 							it.putExtras(mbundle);
 							sendBroadcast(it);
-							
+
 							idex++;
 						}
 					} else {
@@ -416,12 +412,12 @@ public class RadioService extends Service implements RadioInterface,
 						}else if (getRadioType() == RADIO_AM) {
 							mCanRadio.sendRadioInfo(CanRadio.BAND_AM, curFreq);
 						}
-						
+
 						Log.d(TAG, "curFreq(No-Auto) =" + curFreq);
 						if(isLive){
 							mRadioplayerHandler.sendEmptyMessage(UPDATE_DETAIL_FREQ);
 						}
-						
+
 						/****单步时候发送curFreq给Activity广播,调用curFreq_Compare_To_Collect(int curFreq)
 						 ****函数与收藏栏列表的频率作比较,变化爱心图标*************************************/
 						Intent it = new Intent();
@@ -441,11 +437,11 @@ public class RadioService extends Service implements RadioInterface,
 				}
 			} while (status != RADIO_NO_ACTION);
 			if(freq[0] == SEARCH_OVER && STEP_OR_AUTO == IS_AUTO_NOW){
-				//when auto search is complete,set Channal0 with the first freq 
+				//when auto search is complete,set Channal0 with the first freq
 				Intent intent = new Intent("Radio_Auto_Complete");
 				sendBroadcast(intent);
 			}
-			
+
 			FLAG_AUTO = 0;
 			mIsSearchThreadRunning = false;
 			updatePreferences(RADIO_DATA_SAVE);
@@ -503,7 +499,6 @@ public class RadioService extends Service implements RadioInterface,
 
 	@Override
 	public void onAudioFocusChange(int focusChange) {
-		// TODO Auto-generated method stub
 		//if (DEBUG)
 		Log.v(TAG, "----onAudioFocusChange----focusChange:" + focusChange);
 		switch (focusChange) {
@@ -597,7 +592,7 @@ public class RadioService extends Service implements RadioInterface,
 		jniSetVolume(volume);
 		return volume;
 	}
-	
+
 	public int setVolume(int volume) {
 		mVolume = volume;
 		if (DEBUG) Log.v(TAG, "(Service)mVolume = "+mVolume);
@@ -640,31 +635,26 @@ public class RadioService extends Service implements RadioInterface,
 
 	@Override
 	public void setFunctionId(int id) {
-		// TODO Auto-generated method stub
 		functionId = id;
 	}
 
 	@Override
 	public int getFunctionId() {
-		// TODO Auto-generated method stub
 		return functionId;
 	}
 
 	@Override
 	public void setCurrentFreq(int freq) {
-		// TODO Auto-generated method stub
 		curFreq = freq;
 	}
 
 	@Override
 	public int getCurrentFreq() {
-		// TODO Auto-generated method stub
 		return curFreq;
 	}
 
 	@Override
 	public int fineLeft(int freq) {
-		// TODO Auto-generated method stub
 		if (DEBUG)
 			Log.v(TAG, " ++++++++JNI fineLeft worked. Input freq:" + freq);
 		curFreq = jniFineLeft(freq);
@@ -679,13 +669,12 @@ public class RadioService extends Service implements RadioInterface,
 			mRadioplayerHandler.sendEmptyMessage(UPDATE_DETAIL_FREQ);
 		}
 		updatePreferences(RADIO_DATA_SAVE);
-		
+
 		return curFreq;
 	}
 
 	@Override
 	public int fineRight(int freq) {
-		// TODO Auto-generated method stub
 		if (DEBUG)
 			Log.v(TAG, " JNI fineRight worked ");
 		curFreq = jniFineRight(freq);
@@ -704,7 +693,6 @@ public class RadioService extends Service implements RadioInterface,
 
 	@Override
 	public int stepLeft(int freq) {
-		// TODO Auto-generated method stub
 		if (DEBUG)
 			Log.v(TAG, " JNI stepLeft worked ");
 		if (mIsSearchThreadRunning) {
@@ -722,7 +710,6 @@ public class RadioService extends Service implements RadioInterface,
 
 	@Override
 	public int stepRight(int freq) {
-		// TODO Auto-generated method stub
 		if (DEBUG)
 			Log.v(TAG, " JNI stepRight worked ");
 		if (mIsSearchThreadRunning) {
@@ -740,37 +727,31 @@ public class RadioService extends Service implements RadioInterface,
 
 	@Override
 	public int getCurChannelId() {
-		// TODO Auto-generated method stub
 		return curChannelId;
 	}
 
 	@SuppressWarnings("deprecation")
 	@Override
 	public void setCurChannelId(int id) {
-		// TODO Auto-generated method stub
 		curChannelId = id;
 	}
 
 	@Override
 	public void registStatusListener(RadioStatusChangeListener listener) {
-		// TODO Auto-generated method stub
 		mStatusListener = listener;
 	}
 
 	@Override
 	public void unRegistStatusListener() {
-		// TODO Auto-generated method stub
 		mStatusListener = null;
 	}
 
 	public void setRemote(int remote) {
-		// TODO Auto-generated method stub
 		jniSetRemote(remote);
 	}
 
 	@Override
 	public void onAutoSearch() {
-		// TODO Auto-generated method stub
 		if (DEBUG)
 			Log.d(TAG, "onAutoSearch");
 		if (mIsSearchThreadRunning) {
@@ -816,7 +797,6 @@ public class RadioService extends Service implements RadioInterface,
 
 	@Override
 	public void setFreq(int freq) {
-		// TODO Auto-generated method stub
 		Log.v(TAG, "JNI setfreq has worked ------freq is " + freq);
 		if (DEBUG)
 			Log.v(TAG, "JNI setfreq has worked ------freq is " + freq);
@@ -851,7 +831,6 @@ public class RadioService extends Service implements RadioInterface,
 	 * 获取当前系统语言
 	 */
 	private String getLocalLanguage() {
-		// TODO Auto-generated method stub
 		String language = Locale.getDefault().getLanguage();
 //		SharedPreferences.Editor editor = settings.edit(); /* ��editor���ڱ���״̬ */
 //		editor.putString("local_language", language);
@@ -1337,7 +1316,6 @@ public class RadioService extends Service implements RadioInterface,
 
 	@Override
 	public void clearAllContent() {
-		// TODO Auto-generated method stub
 		if (getRadioType() == RADIO_FM1 || getRadioType() == RADIO_FM2) {
 
 			for (int i = 0; i < RADIO_FM_COUNT; i++) {

--- a/Radio/src/com/example/radio/RadioService.java
+++ b/Radio/src/com/example/radio/RadioService.java
@@ -1,23 +1,14 @@
 package com.example.radio;
 
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-
-import org.xmlpull.v1.XmlPullParser;
-import com.radio.widget.RadioPlayerStatusStore;
-
 import android.annotation.SuppressLint;
-import android.app.Notification;
 import android.app.PendingIntent;
 import android.app.Service;
+import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.SharedPreferences;
-import android.content.SharedPreferences.Editor;
-import android.content.pm.PackageManager.NameNotFoundException;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
@@ -28,9 +19,7 @@ import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.location.Address;
 import android.media.AudioManager;
-import android.media.AudioManager.OnAudioFocusChangeListener;
 import android.media.MediaMetadataRetriever;
 import android.media.RemoteControlClient;
 import android.media.RemoteControlClient.MetadataEditor;
@@ -42,11 +31,17 @@ import android.os.Message;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.util.Xml;
-import android.view.KeyEvent;
 import android.widget.Toast;
-import android.content.BroadcastReceiver;
-import android.content.IntentFilter;
+
 import com.android.internal.car.can.CanRadio;
+import com.radio.widget.RadioPlayerStatusStore;
+
+import org.xmlpull.v1.XmlPullParser;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
 public class RadioService extends Service implements RadioInterface,
         AudioManager.OnAudioFocusChangeListener {
@@ -55,6 +50,7 @@ public class RadioService extends Service implements RadioInterface,
     public static final String EXTRA_KEY_STOP = "com.example.radioplayer.key_stop";
     public static final String ACTION_STOP = "com.example.radioplayer.stop";
     public static final String ACTION_NEXT = "com.example.radioplayer.next";
+
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         final String action = intent.getAction();
@@ -65,7 +61,9 @@ public class RadioService extends Service implements RadioInterface,
                 stopSelf();
         }
         if (ACTION_NEXT.equals(action)){
-            if (getFunctionId() == 0) {
+            if (getFunctionId() == FUNCTION_SCAN) {
+                setFunctionId(FUNCTION_STEP_SEEK);
+            } else if (getFunctionId() == FUNCTION_FINE_TUNE) {
                 fineRight(getCurrentFreq());
             } else {
                 stepRight(getCurrentFreq());
@@ -486,14 +484,20 @@ public class RadioService extends Service implements RadioInterface,
 	}
 
 	private String formatFreqDisplay(int freq) {
-		String display = "";
+		return formatFreqDisplay(this, freq);
+	}
+
+	public static String formatFreqDisplay(Context context, int freq) {
+		String display;
+
 		if (freq < 1000) {
 			display = Integer.toString(freq) + " " +
-				getResources().getString(R.string.khz);
+					context.getResources().getString(R.string.khz);
 		} else {
 			display = String.valueOf(freq/100.0) + " " +
-					getResources().getString(R.string.mhz);
+					context.getResources().getString(R.string.mhz);
 		}
+
 		return display;
 	}
 


### PR DESCRIPTION
Adds the ability to "Scan" radio frequencies.  Virtually every car radio has this feature, so it's a feature that is sorely missing from this Radio app.
- Some of the Radio code has been cleaned up: whitespace trimmed, `//TODO Auto-generated` comments removed, empty Dialog click listeners removed, imports organized, etc...
- Some strings have been "translated" in the `en-rUS` locale, to make them more US-friendly (i.e., "Fine" -> "Tune";  "Step" -> "Seek"). These changes were done here instead of in the default `values/strings.xml` file, just in case that's a terminology that people outside the US are more familiar with.  In USA, "Tune" and "Seek" are more familiar.

Then the Scan mode updates:
1. Long-press on the "Seek" button enters the "Scan" mode.
2. Adds a "Scan Delay" preference to configure how long to wait on each frequency before skipping to the next.

The feature is especially useful when traveling outside of your "home" area, where you aren't familiar with radio stations -- but you don't want to use the "Auto" search function, as that would wipe out all of your saved stations.

Instead, entering a scan mode simply steps to each tunable frequency, pausing between each station. If you hear a station that you'd like to stop on, you can cancel the scan mode by pressing the "Seek" button again, or by pressing the forward/backward arrow buttons.

This closes jhansche/packages_apps_bonovoapps#2
