### PR TITLE
Set a duration in the MediaMetadata

### DIFF
--- a/Radio/src/com/example/radio/RadioService.java
+++ b/Radio/src/com/example/radio/RadioService.java
@@ -485,6 +485,7 @@ public class RadioService extends Service implements RadioInterface,
 		editor.putString(MediaMetadataRetriever.METADATA_KEY_ALBUM, album);
 		editor.putString(MediaMetadataRetriever.METADATA_KEY_ARTIST, artist);
 		editor.putString(MediaMetadataRetriever.METADATA_KEY_TITLE,song);
+		editor.putLong(MediaMetadataRetriever.METADATA_KEY_DURATION, Long.MAX_VALUE);
 
 		editor.apply();
 	}


### PR DESCRIPTION
Some apps (like AutoMate) will only enable Next/Prev buttons if the playing
media has a duration >= 0. Since the Radio station doesn't actually have a
known "duration," that was previously left disabled (0 seconds).

Technically one could argue that the duration of a radio station is infinite,
so setting the station's duration to Long.MAX_VALUE would theoretically be
accurate.

And by doing so, it enables the Next/Prev buttons to work properly in apps
like AutoMate.
